### PR TITLE
@PiyushChawla Changed datatype from Node to URI in function "getPredicates"

### DIFF
--- a/sansa-rdf-spark-parent/sansa-rdf-spark-core/src/main/scala/net/sansa_stack/rdf/spark/model/TripleRDD.scala
+++ b/sansa-rdf-spark-parent/sansa-rdf-spark-core/src/main/scala/net/sansa_stack/rdf/spark/model/TripleRDD.scala
@@ -18,7 +18,7 @@ class TripleRDD(@transient graphRDD: JenaSparkRDD#Graph) extends Serializable wi
   def getSubjects: RDD[JenaSparkRDD#Node] =
     graphRDD.map(_.getSubject)
 
-  def getPredicates: RDD[JenaSparkRDD#Node] =
+  def getPredicates: RDD[JenaSparkRDD#URI] =
     graphRDD.map(_.getPredicate)
 
   def getObjects: RDD[JenaSparkRDD#Node] =


### PR DESCRIPTION
Now the programmer doesn't need to explicitly type cast the RDD  when calling this function.