### PR TITLE
Fix for rdf_loader parse error

### DIFF
--- a/sansa-rdf-spark-parent/sansa-rdf-spark-core/src/main/resources/rdf_loader.conf
+++ b/sansa-rdf-spark-parent/sansa-rdf-spark-core/src/main/resources/rdf_loader.conf
@@ -2,4 +2,4 @@
 rdf.ntriples.parser = regex
 rdf.turtle.parser = jena
 
-rdf.parser.skipinvalid
+rdf.parser.skipinvalid = true


### PR DESCRIPTION
This is a fix for the rdf_loader parsing error https://github.com/SANSA-Stack/SANSA-RDF/issues/28. The fix simply appends true to one of the configuration parameters.
