### PR TITLE
Feature/rdfstats refactoring

### DIFF
--- a/sansa-rdf-common/src/main/java/net/sansa_stack/rdf/benchmark/io/SansaBenchRdfIo.java
+++ b/sansa-rdf-common/src/main/java/net/sansa_stack/rdf/benchmark/io/SansaBenchRdfIo.java
@@ -38,7 +38,6 @@ import org.apache.jena.riot.lang.PipedRDFStream;
 import org.apache.jena.riot.lang.PipedTriplesStream;
 import org.apache.jena.riot.lang.RiotParsers;
 import org.apache.jena.riot.system.ParserProfile;
-import org.apache.jena.riot.system.ParserProfileStd;
 import org.apache.jena.riot.system.RiotLib;
 import org.apache.jena.riot.tokens.TokenizerFactory;
 import org.apache.jena.shared.SyntaxError;

--- a/sansa-rdf-spark/pom.xml
+++ b/sansa-rdf-spark/pom.xml
@@ -145,6 +145,10 @@
 				<groupId>org.scalastyle</groupId>
 				<artifactId>scalastyle-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/sansa-rdf-spark/src/main/scala/net/sansa_stack/rdf/spark/io/RDFSparseTensorReader.scala
+++ b/sansa-rdf-spark/src/main/scala/net/sansa_stack/rdf/spark/io/RDFSparseTensorReader.scala
@@ -32,7 +32,7 @@ class RDFSparseTensorReader(spark: SparkSession, path: String) {
 
   def getNumRelations = relationIDs.count()
 
-  def getMappedTriples(): Unit = {
+  def getMappedTriples() = {
     val joinedBySubject = entityIDs.join(triplesWithURIs.map { triple =>
       (triple.getSubject(), (triple.getPredicate, triple.getObject))
     })

--- a/sansa-rdf-spark/src/main/scala/net/sansa_stack/rdf/spark/model/package.scala
+++ b/sansa-rdf-spark/src/main/scala/net/sansa_stack/rdf/spark/model/package.scala
@@ -23,7 +23,8 @@ package object model {
      * @return a DataFrame of triples.
      * @see [[net.sansa_stack.rdf.spark.model.rdd.TripleOps.toDF]]
      */
-    def toDF() = TripleOps.toDF(triples)
+    def toDF() =
+      TripleOps.toDF(triples)
 
     /**
      * Convert an RDD of Triple into a Dataset of Triple.
@@ -60,7 +61,8 @@ package object model {
      * @return [[RDD[Triple]]] a subset of the given RDD.
      * @see [[net.sansa_stack.rdf.spark.model.rdd.TripleOps.filterSubjects]]
      */
-    def filterSubjects(func: Node => Boolean) = TripleOps.filterSubjects(triples, func)
+    def filterSubjects(func: Node => Boolean) =
+      TripleOps.filterSubjects(triples, func)
 
     /**
      * Filter out the predicates from a given RDD[Triple],
@@ -69,7 +71,8 @@ package object model {
      * @return [[RDD[Triple]]] a subset of the given RDD.
      * @see [[net.sansa_stack.rdf.spark.model.rdd.TripleOps.filterPredicates]]
      */
-    def filterPredicates(func: Node => Boolean) = TripleOps.filterPredicates(triples, func)
+    def filterPredicates(func: Node => Boolean) =
+      TripleOps.filterPredicates(triples, func)
 
     /**
      * Filter out the objects from a given RDD[Triple],
@@ -78,7 +81,80 @@ package object model {
      * @return [[RDD[Triple]]] a subset of the given RDD.
      * @see [[net.sansa_stack.rdf.spark.model.rdd.TripleOps.filterObjects]]
      */
-    def filterObjects(func: Node => Boolean) = TripleOps.filterObjects(triples, func)
+    def filterObjects(func: Node => Boolean) =
+      TripleOps.filterObjects(triples, func)
+
+    /**
+     * Returns an RDD of triples that match with the given input.
+     *
+     * @param subject the subject
+     * @param predicate the predicate
+     * @param object the object
+     * @return RDD of triples
+     * @see [[net.sansa_stack.rdf.spark.model.rdd.TripleOps.find]]
+     */
+    def find(subject: Option[Node] = None, predicate: Option[Node] = None, `object`: Option[Node] = None) =
+      TripleOps.find(triples, subject, predicate, `object`)
+
+    /**
+     * Returns an RDD of triples that match with the given input.
+     *
+     * @param triple the triple to be checked
+     * @return RDD of triples that match the given input
+     * @see [[net.sansa_stack.rdf.spark.model.rdd.TripleOps.find]]
+     */
+    def find(triple: Triple): RDD[Triple] = TripleOps.find(triples, triple)
+
+    /**
+     * Determine whether this RDF graph contains any triples
+     * with a given subject and predicate.
+     *
+     * @param subject the subject (None for any)
+     * @param predicate the predicate (Node for any)
+     * @return true if there exists within this RDF graph
+     * a triple with subject and predicate, false otherwise
+     */
+    def contains(subject: Some[Node], predicate: Some[Node]) =
+      TripleOps.contains(triples, subject, predicate, None)
+
+    /**
+     * Determine whether this RDF graph contains any triples
+     * with a given (subject, predicate, object) pattern.
+     *
+     * @param subject the subject (None for any)
+     * @param predicate the predicate (Node for any)
+     * @param object the object (Node for any)
+     * @return true if there exists within this RDF graph
+     * a triple with (S, P, O) pattern, false otherwise
+     */
+    def contains(subject: Some[Node], predicate: Some[Node], `object`: Some[Node]) =
+      TripleOps.contains(triples, subject, predicate, `object`)
+
+    /**
+     * Determine if a triple is present in this RDF graph.
+     *
+     * @param triple the triple to be checked
+     * @return true if the statement s is in this RDF graph, false otherwise
+     */
+    def contains(triple: Triple) = TripleOps.contains(triples, triple)
+
+    /**
+     * Determine if any of the triples in an RDF graph are also contained in this RDF graph.
+     *
+     * @param other the other RDF graph containing the statements to be tested
+     * @return true if any of the statements in RDF graph are also contained
+     * in this RDF graph and false otherwise.
+     */
+    def containsAny(other: RDD[Triple]) = TripleOps.containsAny(triples, other)
+
+    /**
+     * Determine if all of the statements in an RDF graph are also contained in this RDF graph.
+     *
+     * @param other the other RDF graph containing the statements to be tested
+     * @return true if all of the statements in RDF graph are also contained
+     * in this RDF graph and false otherwise.
+     */
+    def containsAll(other: RDD[Triple]) = TripleOps.containsAll(triples, other)
 
     /**
      * Return the number of triples.
@@ -102,7 +178,8 @@ package object model {
      * @return graph (union of all)
      * @see [[net.sansa_stack.rdf.spark.model.rdd.TripleOps.unionAll]]
      */
-    def unionAll(others: Seq[RDD[Triple]]) = TripleOps.unionAll(triples, others)
+    def unionAll(others: Seq[RDD[Triple]]) =
+      TripleOps.unionAll(triples, others)
 
     /**
      * Returns a new RDF graph that contains the intersection of the current RDF graph with the given RDF graph.
@@ -111,7 +188,8 @@ package object model {
      * @return the intersection of both RDF graphs
      * @see [[net.sansa_stack.rdf.spark.model.rdd.TripleOps.intersection]]
      */
-    def intersection(other: RDD[Triple]) = TripleOps.intersection(triples, other)
+    def intersection(other: RDD[Triple]) =
+      TripleOps.intersection(triples, other)
     /**
      * Returns a new RDF graph that contains the difference between the current RDF graph and the given RDF graph.
      *
@@ -163,7 +241,8 @@ package object model {
      * @param path path to the file containing N-Triples
      * @see [[net.sansa_stack.rdf.spark.model.rdd.TripleOps.saveAsNTriplesFile]]
      */
-    def saveAsNTriplesFile(path: String) = TripleOps.saveAsNTriplesFile(triples, path)
+    def saveAsNTriplesFile(path: String) =
+      TripleOps.saveAsNTriplesFile(triples, path)
 
   }
 

--- a/sansa-rdf-spark/src/main/scala/net/sansa_stack/rdf/spark/model/rdd/TripleOps.scala
+++ b/sansa-rdf-spark/src/main/scala/net/sansa_stack/rdf/spark/model/rdd/TripleOps.scala
@@ -125,15 +125,16 @@ object TripleOps {
    */
   def find(triples: RDD[Triple], subject: Option[Node] = None, predicate: Option[Node] = None, `object`: Option[Node] = None): RDD[Triple] = {
     triples.filter(t =>
-      (subject == None || t.getSubject == subject.get) &&
-        (predicate == None || t.getPredicate == predicate.get) &&
-        (`object` == None || t.getObject == `object`.get))
+      (subject == None || t.getSubject.matches(subject.get)) &&
+        (predicate == None || t.getPredicate.matches(predicate.get)) &&
+        (`object` == None || t.getObject.matches(`object`.get)))
   }
 
   /**
    * Returns an RDD of triples that match with the given input.
    *
    * @param triples RDD of triples
+   * @param triple  the triple to be checked
    * @return RDD of triples that match the given input
    */
   def find(triples: RDD[Triple], triple: Triple): RDD[Triple] = {
@@ -199,20 +200,6 @@ object TripleOps {
 
   /**
    * Determine whether this RDF graph contains any triples
-   * with a given subject and predicate.
-   *
-   * @param triples RDD of triples
-   * @param subject the subject (None for any)
-   * @param predicate the predicate (Node for any)
-   * @return true if there exists within this RDF graph
-   * a triple with subject and predicate, false otherwise
-   */
-  def contains(triples: RDD[Triple], subject: Some[Node], predicate: Some[Node]): Boolean = {
-    find(triples, subject, predicate, None).count() > 0
-  }
-
-  /**
-   * Determine whether this RDF graph contains any triples
    * with a given (subject, predicate, object) pattern.
    *
    * @param triples RDD of triples
@@ -222,7 +209,7 @@ object TripleOps {
    * @return true if there exists within this RDF graph
    * a triple with (S, P, O) pattern, false otherwise
    */
-  def contains(triples: RDD[Triple], subject: Some[Node], predicate: Some[Node], `object`: Some[Node]): Boolean = {
+  def contains(triples: RDD[Triple], subject: Option[Node] = None, predicate: Option[Node] = None, `object`: Option[Node] = None): Boolean = {
     find(triples, subject, predicate, `object`).count() > 0
   }
 

--- a/sansa-rdf-spark/src/main/scala/net/sansa_stack/rdf/spark/partition/semantic/RdfPartition.scala
+++ b/sansa-rdf-spark/src/main/scala/net/sansa_stack/rdf/spark/partition/semantic/RdfPartition.scala
@@ -4,8 +4,6 @@ import java.util.concurrent.TimeUnit
 import org.apache.jena.graph.Triple
 import org.apache.spark.rdd._
 
-import net.sansa_stack.rdf.spark.partition.semantic.RdfPartition;
-
 /*
  * RdfPartition - semantic partition of and RDF graph
  * @symbol - list of symbols.

--- a/sansa-rdf-spark/src/main/scala/net/sansa_stack/rdf/spark/stats/package.scala
+++ b/sansa-rdf-spark/src/main/scala/net/sansa_stack/rdf/spark/stats/package.scala
@@ -40,7 +40,7 @@ package object stats {
      * <b>Action</b> : `M[?o]++ `
      * @return RDD of classes used in the dataset and their frequencies.
      */
-    def statsClassUsage() = Used_Classes(triples, spark).Action()
+    def statsClassUsageCount() = Used_Classes(triples, spark).Action()
 
     /**
      * <b>3. Classes Defined Criterion </b> <br>
@@ -121,7 +121,7 @@ package object stats {
      * <b>Action</b> : `M[ns]++`
      * @return RDD of distinct object vocabularies used in the dataset and their frequencies.
      */
-    def statsObjectVocabulariesPostProc() = SPO_Vocabularies(triples, spark).ObjectVocabulariesPostProc()
+    def statsObjectVocabularies() = SPO_Vocabularies(triples, spark).ObjectVocabulariesPostProc()
 
     /**
      * <b>Distinct Subjects</b> <br>
@@ -154,7 +154,20 @@ package object stats {
   }
 
   implicit class StatsCriteriaVoidify(stats: RDD[String]) extends Logging {
+
+    /**
+     * Voidify RDF dataset based on the Vocabulary of Interlinked Datasets (VoID) [[https://www.w3.org/TR/void/]]
+     *
+     * @param source name of the Dataset:source--usualy the file's name
+     * @param output the directory to save RDF dataset summary
+     */
     def voidify(source: String, output: String) = RDFStatistics.voidify(stats, source, output)
+
+    /**
+     * Prints the Voidiy version of the given RDF dataset
+     *
+     * @param source name of the Dataset:source--usualy the file's name
+     */
     def print(source: String) = RDFStatistics.print(stats, source)
   }
 }

--- a/sansa-rdf-spark/src/main/scala/net/sansa_stack/rdf/spark/stats/package.scala
+++ b/sansa-rdf-spark/src/main/scala/net/sansa_stack/rdf/spark/stats/package.scala
@@ -1,0 +1,160 @@
+package net.sansa_stack.rdf.spark
+
+import net.sansa_stack.rdf.spark.utils.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.jena.graph.{ Node, Triple }
+import org.apache.spark.sql.SparkSession
+
+package object stats {
+
+  implicit class StatsCriteria(triples: RDD[Triple]) extends Logging {
+    @transient val spark: SparkSession = SparkSession.builder().getOrCreate()
+
+    /**
+     * Compute distributed RDF dataset statistics.
+     * @return VoID description of the given dataset
+     */
+    def stats = RDFStatistics.run(triples)
+
+    /**
+     * <b>1. Used Classes Criterion </b> <br>
+     * Creates an RDD of classes are in use by instances of the analyzed dataset.
+     * As an example of such a triple that will be accepted by
+     * the filter is `sda:Gezim rdf:type distLODStats:Developer`.
+     * <b>Filter rule</b> : `?p=rdf:type && isIRI(?o)`
+     * <b>Action</b> : `S += ?o`
+     * @return RDD of classes/instances
+     */
+    def statsUsedClasses() = Used_Classes(triples, spark).Filter()
+
+    /**
+     * <b>2. Class Usage Count Criterion </b> <br>
+     * Count the usage of respective classes of a datase,
+     * the filter rule that is used to analyze a triple is the
+     * same as in the first criterion.
+     * As an action a map is being created having class IRIs as
+     * identifier and its respective usage count as value.
+     * If a triple is conform to the filter rule the respective
+     * value will be increased by one.
+     * <b>Filter rule</b> : `?p=rdf:type && isIRI(?o)`
+     * <b>Action</b> : `M[?o]++ `
+     * @return RDD of classes used in the dataset and their frequencies.
+     */
+    def statsClassUsage() = Used_Classes(triples, spark).Action()
+
+    /**
+     * <b>3. Classes Defined Criterion </b> <br>
+     * Gets a set of classes that are defined within a
+     * dataset this criterion is being used.
+     * Usually in RDF/S and OWL a class can be defined by a triple
+     * using the predicate `rdf:type` and either `rdfs:Class` or
+     * `owl:Class` as object.
+     * The filter rule illustrates the condition used to analyze the triple.
+     * If the triple is accepted by the rule, the IRI used as subject is added to the set of classes.
+     * <b>Filter rule</b> : `?p=rdf:type && isIRI(?s) &&(?o=rdfs:Class||?o=owl:Class)`
+     * <b>Action</b> : `S += ?s `
+     * @return RDD of classes defined in the dataset.
+     */
+    def statsClassesDefined() = Classes_Defined(triples, spark).Action()
+
+    /**
+     * <b>5. Property Usage Criterion </b> <br>
+     * Count the usage of properties within triples.
+     * Therefore an RDD will be created containing all property
+     * IRI's as identifier.
+     * Afterwards, their frequencies will be computed.
+     * <b>Filter rule</b> : `none`
+     * <b>Action</b> : `M[?p]++ `
+     * @return RDD of predicates used in the dataset and their frequencies.
+     */
+    def statsPropertyUsage() = PropertyUsage(triples, spark).Action()
+
+    /**
+     * <b>6. Property usage distinct per subject  </b> <br>
+     * Count the usage of properties within triples based on subjects.
+     * <b>Filter rule</b> : `none`
+     * <b>Action</b> : `M[?s] += ?p `
+     * @return RDD of predicates used in the dataset and their frequencies.
+     */
+    def statsPropertyUsageDistinctPerSubject() = OtherStats.PropertyUsageDistinctPerSubject(triples)
+
+    /**
+     * <b>7. Property usage distinct per object   </b> <br>
+     * Count the usage of properties within triples based on objects.
+     * <b>Filter rule</b> : `none`
+     * <b>Action</b> : `M[?o] += ?p `
+     * @return RDD of predicates used in the dataset and their frequencies.
+     */
+    def statsPropertyUsageDistinctPerObject() = OtherStats.PropertyUsageDistinctPerObject(triples)
+
+    /**
+     * <b>16. Distinct entities </b> <br>
+     * Count distinct entities of a dataset by filtering out all IRIs.
+     * <b>Filter rule</b> : `S+=iris({?s,?p,?o})`
+     * <b>Action</b> : `S`
+     * @return RDD of distinct entities in the dataset.
+     */
+    def statsDistinctEntities() = DistinctEntities(triples, spark).Action()
+
+    /**
+     * <b>30. Subject vocabularies </b> <br>
+     * Compute subject vocabularies/namespaces used through the dataset.
+     * <b>Filter rule</b> : `ns=ns(?s)`
+     * <b>Action</b> : `M[ns]++`
+     * @return RDD of distinct subject vocabularies used in the dataset and their frequencies.
+     */
+    def statsSubjectVocabularies() = SPO_Vocabularies(triples, spark).SubjectVocabulariesPostProc()
+
+    /**
+     * <b>31. Predicate vocabularies </b> <br>
+     * Compute predicate vocabularies/namespaces used through the dataset.
+     * <b>Filter rule</b> : `ns=ns(?p)`
+     * <b>Action</b> : `M[ns]++`
+     * @return RDD of distinct predicate vocabularies used in the dataset and their frequencies.
+     */
+    def statsPredicateVocabularies() = SPO_Vocabularies(triples, spark).PredicateVocabulariesPostProc()
+
+    /**
+     * <b>32. Object vocabularies </b> <br>
+     * Compute object vocabularies/namespaces used through the dataset.
+     * <b>Filter rule</b> : `ns=ns(?o)`
+     * <b>Action</b> : `M[ns]++`
+     * @return RDD of distinct object vocabularies used in the dataset and their frequencies.
+     */
+    def statsObjectVocabulariesPostProc() = SPO_Vocabularies(triples, spark).ObjectVocabulariesPostProc()
+
+    /**
+     * <b>Distinct Subjects</b> <br>
+     * Count distinct subject within triples.
+     * <b>Filter rule</b> : `isURI(?s)`
+     * <b>Action</b> : `M[?s]++`
+     * @return RDD of subjects used in the dataset.
+     */
+    def statsDistinctSubjects() = DistinctSubjects(triples, spark).Action()
+
+    /**
+     * <b>Distinct Objects</b> <br>
+     * Count distinct objects within triples.
+     * <b>Filter rule</b> : `isURI(?o)`
+     * <b>Action</b> : `M[?o]++`
+     * @return RDD of objects used in the dataset.
+     */
+    def statsDistinctObjects() = DistinctObjects(triples, spark).Action()
+
+    /**
+     * <b>Properties Defined</b> <br>
+     * Count the defined properties within triples.
+     * <b>Filter rule</b> : `?p=rdf:type &&  (?o=owl:ObjectProperty ||
+     *  ?o=rdf:Property)&& !isIRI(?s)`
+     * <b>Action</b> : `M[?p]++`
+     * @return RDD of predicates defined in the dataset.
+     */
+    def statsPropertiesDefined() = PropertiesDefined(triples, spark).Action()
+
+  }
+
+  implicit class StatsCriteriaVoidify(stats: RDD[String]) extends Logging {
+    def voidify(source: String, output: String) = RDFStatistics.voidify(stats, source, output)
+    def print(source: String) = RDFStatistics.print(stats, source)
+  }
+}

--- a/sansa-rdf-spark/src/test/scala/net/sansa_stack/rdf/spark/stats/RDFStatsTests.scala
+++ b/sansa-rdf-spark/src/test/scala/net/sansa_stack/rdf/spark/stats/RDFStatsTests.scala
@@ -1,0 +1,23 @@
+package net.sansa_stack.rdf.spark.stats
+
+import org.scalatest.FunSuite
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
+import org.apache.jena.riot.Lang
+import net.sansa_stack.rdf.spark.io._
+
+class RDFStatsTests extends FunSuite with DataFrameSuiteBase {
+
+  import net.sansa_stack.rdf.spark.stats._
+
+  test("computing distinct subjects should result in size 3") {
+    val path = getClass.getResource("/loader/data.nt").getPath
+    val lang: Lang = Lang.NTRIPLES
+
+    val triples = spark.rdf(lang, allowBlankLines = true)(path)
+
+    val distinct_subjects = triples.statsDistinctSubjects()
+
+    assert(distinct_subjects.count() == 3)
+  }
+
+}

--- a/sansa-rdf-spark/src/test/scala/net/sansa_stack/rdf/spark/stats/RDFStatsTests.scala
+++ b/sansa-rdf-spark/src/test/scala/net/sansa_stack/rdf/spark/stats/RDFStatsTests.scala
@@ -15,9 +15,142 @@ class RDFStatsTests extends FunSuite with DataFrameSuiteBase {
 
     val triples = spark.rdf(lang, allowBlankLines = true)(path)
 
-    val distinct_subjects = triples.statsDistinctSubjects()
+    val criteria = triples.statsDistinctSubjects()
+    val cnt = criteria.count()
 
-    assert(distinct_subjects.count() == 3)
+    assert(cnt == 3)
+  }
+
+  test("computing Used Classes should result in size 0") {
+    val path = getClass.getResource("/loader/data.nt").getPath
+    val lang: Lang = Lang.NTRIPLES
+
+    val triples = spark.rdf(lang, allowBlankLines = true)(path)
+
+    val criteria = triples.statsUsedClasses()
+    val cnt = criteria.count()
+
+    assert(cnt == 0)
+  }
+
+  test("computing Class Usage Count should result in size 0") {
+    val path = getClass.getResource("/loader/data.nt").getPath
+    val lang: Lang = Lang.NTRIPLES
+
+    val triples = spark.rdf(lang, allowBlankLines = true)(path)
+
+    val criteria = triples.statsClassUsageCount()
+    val cnt = criteria.count()
+
+    assert(cnt == 0)
+  }
+
+  test("computing Classes Defined should result in size 0") {
+    val path = getClass.getResource("/loader/data.nt").getPath
+    val lang: Lang = Lang.NTRIPLES
+
+    val triples = spark.rdf(lang, allowBlankLines = true)(path)
+
+    val criteria = triples.statsClassesDefined()
+    val cnt = criteria.count()
+
+    assert(cnt == 0)
+  }
+
+  test("computing Property Usage should result in size 6") {
+    val path = getClass.getResource("/loader/data.nt").getPath
+    val lang: Lang = Lang.NTRIPLES
+
+    val triples = spark.rdf(lang, allowBlankLines = true)(path)
+
+    val criteria = triples.statsPropertyUsage()
+    val cnt = criteria.count()
+
+    assert(cnt == 6)
+  }
+
+  test("computing Distinct Entities should result in size 0") {
+    val path = getClass.getResource("/loader/data.nt").getPath
+    val lang: Lang = Lang.NTRIPLES
+
+    val triples = spark.rdf(lang, allowBlankLines = true)(path)
+
+    val criteria = triples.statsDistinctEntities()
+    val cnt = criteria.count()
+
+    assert(cnt == 0)
+  }
+
+  test("computing Distinct Subjects should result in size 3") {
+    val path = getClass.getResource("/loader/data.nt").getPath
+    val lang: Lang = Lang.NTRIPLES
+
+    val triples = spark.rdf(lang, allowBlankLines = true)(path)
+
+    val criteria = triples.statsDistinctSubjects()
+    val cnt = criteria.count()
+
+    assert(cnt == 3)
+  }
+
+  test("computing Distinct Objects should result in size 0") {
+    val path = getClass.getResource("/loader/data.nt").getPath
+    val lang: Lang = Lang.NTRIPLES
+
+    val triples = spark.rdf(lang, allowBlankLines = true)(path)
+
+    val criteria = triples.statsDistinctObjects()
+    val cnt = criteria.count()
+
+    assert(cnt == 0)
+  }
+
+  test("computing Subject Vocabularies should result in size 3") {
+    val path = getClass.getResource("/loader/data.nt").getPath
+    val lang: Lang = Lang.NTRIPLES
+
+    val triples = spark.rdf(lang, allowBlankLines = true)(path)
+
+    val criteria = triples.statsSubjectVocabularies()
+    val cnt = criteria.count()
+
+    assert(cnt == 3)
+  }
+
+  test("computing Predicate Vocabularies should result in size 5") {
+    val path = getClass.getResource("/loader/data.nt").getPath
+    val lang: Lang = Lang.NTRIPLES
+
+    val triples = spark.rdf(lang, allowBlankLines = true)(path)
+
+    val criteria = triples.statsPredicateVocabularies()
+    val cnt = criteria.count()
+
+    assert(cnt == 5)
+  }
+
+  test("computing Object Vocabularies should result in size 0") {
+    val path = getClass.getResource("/loader/data.nt").getPath
+    val lang: Lang = Lang.NTRIPLES
+
+    val triples = spark.rdf(lang, allowBlankLines = true)(path)
+
+    val criteria = triples.statsObjectVocabularies()
+    val cnt = criteria.count()
+
+    assert(cnt == 0)
+  }
+
+  test("computing Properties Defined should result in size 0") {
+    val path = getClass.getResource("/loader/data.nt").getPath
+    val lang: Lang = Lang.NTRIPLES
+
+    val triples = spark.rdf(lang, allowBlankLines = true)(path)
+
+    val criteria = triples.statsPropertiesDefined()
+    val cnt = criteria.count()
+
+    assert(cnt == 0)
   }
 
 }


### PR DESCRIPTION
This PR proposes a new way of calling RDF Stats Criterion (see below as an example how to call Property Distribution Criterion) and some minor changes and new implementation on TripleOps.

```scala
import net.sansa_stack.rdf.spark.io._

val triples = spark.rdf(lang)(path)
val stats_property_distribution = triples.statsPropertyUsage()
```
Feel free to review and propose any new changes.
Best regards,