### PR TITLE
Remove SparkRDDGraphOps from JenaKryoRegistrator

### DIFF
--- a/sansa-rdf-spark/src/main/scala/net/sansa_stack/rdf/spark/io/JenaKryoRegistrator.scala
+++ b/sansa-rdf-spark/src/main/scala/net/sansa_stack/rdf/spark/io/JenaKryoRegistrator.scala
@@ -28,7 +28,7 @@ class JenaKryoRegistrator extends KryoRegistrator {
     kryo.register(classOf[org.apache.jena.graph.Node_Literal], new NodeSerializer)
     kryo.register(classOf[org.apache.jena.graph.Triple], new TripleSerializer)
     kryo.register(classOf[Array[org.apache.jena.graph.Triple]])
-    kryo.register(Class.forName("net.sansa_stack.rdf.spark.model.SparkRDDGraphOps$$anonfun$findGraph$1"))
+    //kryo.register(Class.forName("net.sansa_stack.rdf.spark.model.SparkRDDGraphOps$$anonfun$findGraph$1"))
     kryo.register(classOf[scala.collection.mutable.WrappedArray.ofRef[_]])
     //kryo.register(classOf[net.sansa_stack.rdf.spark.model.TripleRDD])
   }


### PR DESCRIPTION
Hi,
this PR remove the hardcoded class name on our JenaKryoRegistrator and since it has been used on [Sparqlify example](https://github.com/SANSA-Stack/SANSA-Examples/blob/develop/sansa-examples-spark/src/main/scala/net/sansa_stack/examples/spark/query/Sparqlify.scala#L40), without this fix the example does not run.

Best regards,
