### PR TITLE
Remove sortBy operation for semantic-based partition.

### DIFF
--- a/sansa-rdf-spark/src/main/scala/net/sansa_stack/rdf/spark/partition/semantic/SemanticRdfPartitionUtilsSpark.scala
+++ b/sansa-rdf-spark/src/main/scala/net/sansa_stack/rdf/spark/partition/semantic/SemanticRdfPartitionUtilsSpark.scala
@@ -59,7 +59,8 @@ object SemanticRdfPartitionUtilsSpark extends Serializable {
           filteredPredicate + symbol("space") + filteredObject + symbol("space"))
       })
       .reduceByKey(_ + _) // group based on key
-      .sortBy(x => x._1) // sort by key
+      // .sortBy(x => x._1) // sort by key
+      // .map(_.swap).sortByKey(false)
       .map(x => x._1 + symbol("space") + x._2) // output format
 
     partitionedData


### PR DESCRIPTION
It was causing shuffling overhead, therefore some of the queries weren't able to be evaluated when running on the cluster mode.
The sortBy operator was optional, therefore removing it will not impact the query result set.