### PR TITLE
Feature: Bump Spark and Flink versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<scala.classifier>${scala.binary.version}</scala.classifier>
 		<scala.version.suffix>_${scala.binary.version}</scala.version.suffix>
 
-		<flink.version>1.7.0</flink.version>
+		<flink.version>1.8.0</flink.version>
 		<spark.version>2.4.3</spark.version>
 		<jena.version>3.9.0</jena.version>
 		<jsa.subversion>3</jsa.subversion>
@@ -163,7 +163,17 @@
 			</dependency>
 			<dependency>
 				<groupId>org.apache.flink</groupId>
-				<artifactId>flink-table_${scala.binary.version}</artifactId>
+				<artifactId>flink-table-common</artifactId>
+				<version>${flink.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.flink</groupId>
+				<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+				<version>${flink.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.flink</groupId>
+				<artifactId>flink-table-api-scala_${scala.binary.version}</artifactId>
 				<version>${flink.version}</version>
 			</dependency>
 			<!-- required since Flink 1.3 to custom Hadoop based input formats -->

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 		<scala.version.suffix>_${scala.binary.version}</scala.version.suffix>
 
 		<flink.version>1.7.0</flink.version>
-		<spark.version>2.4.0</spark.version>
+		<spark.version>2.4.3</spark.version>
 		<jena.version>3.9.0</jena.version>
 		<jsa.subversion>3</jsa.subversion>
 		<hadoop.version>2.8.3</hadoop.version>

--- a/sansa-rdf-flink/pom.xml
+++ b/sansa-rdf-flink/pom.xml
@@ -52,7 +52,15 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table_${scala.binary.version}</artifactId>
+			<artifactId>flink-table-common</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-api-scala_${scala.binary.version}</artifactId>
 		</dependency>
 
 		<!-- Apache JENA 3.x -->


### PR DESCRIPTION
This PR bumps the Spark version to `2.4.3` and Flink version to `1.8.0`.